### PR TITLE
Use `String.splitter` instead of `String.split` in Flow notebook.

### DIFF
--- a/04-flow.livemd
+++ b/04-flow.livemd
@@ -67,7 +67,7 @@ result =
     Req.get!("https://baconipsum.com/api/?type=meat-and-filler&paras=50&format=text").body
   end)
   |> Stream.flat_map(fn paragraph ->
-    String.split(paragraph, "\n", trim: true)
+    String.splitter(paragraph, "\n", trim: true)
   end)
   |> Stream.flat_map(&String.split(&1, " ", trim: true))
   |> Enum.reduce(%{}, fn word, acc ->
@@ -104,7 +104,7 @@ result =
   |> Flow.flat_map(fn paragraph ->
     String.split(paragraph, "\n", trim: true)
   end)
-  |> Flow.flat_map(&String.split(&1, " ", trim: true))
+  |> Flow.flat_map(&String.splitter(&1, " ", trim: true))
   |> Flow.partition()
   |> Flow.reduce(fn -> %{} end, fn word, acc ->
     Map.update(acc, word, 1, &(&1 + 1))

--- a/04-flow.livemd
+++ b/04-flow.livemd
@@ -69,7 +69,7 @@ result =
   |> Stream.flat_map(fn paragraph ->
     String.splitter(paragraph, "\n", trim: true)
   end)
-  |> Stream.flat_map(&String.split(&1, " ", trim: true))
+  |> Stream.flat_map(&String.splitter(&1, " ", trim: true))
   |> Enum.reduce(%{}, fn word, acc ->
     Map.update(acc, word, 1, &(&1 + 1))
   end)
@@ -102,7 +102,7 @@ result =
     Req.get!("https://baconipsum.com/api/?type=meat-and-filler&paras=50&format=text").body
   end)
   |> Flow.flat_map(fn paragraph ->
-    String.split(paragraph, "\n", trim: true)
+    String.splitter(paragraph, "\n", trim: true)
   end)
   |> Flow.flat_map(&String.splitter(&1, " ", trim: true))
   |> Flow.partition()


### PR DESCRIPTION
The Flow notebook uses `String.split` instead of `String.splitter` which is described as better in the markdown. 

This PR fixes that.
I am not sure if `String.splitter` should also be used when splitting the words on each line though.

Thanks for sharing!