### PR TITLE
Remove non-existing :case option in Base.encode64

### DIFF
--- a/03-genstage.livemd
+++ b/03-genstage.livemd
@@ -170,7 +170,7 @@ defmodule Hasher do
   def handle_events(events, _from, :nostate) do
     events =
       for event <- events do
-        {event, Base.encode64(:erlang.md5(event), case: :lower)}
+        {event, Base.encode64(:erlang.md5(event))}
       end
 
     # Here, "events" is not empty.


### PR DESCRIPTION
Unless I'm missing something, there's no such thing as a `:case` option in [`Base64.encode/2`](https://hexdocs.pm/elixir/1.16.0/Base.html#encode64/2), so this wasn't doing anything.